### PR TITLE
Usa a validade informada no painel para o pagamento com PIX

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -125,6 +125,11 @@ class Data extends AbstractHelper
 		return $this->getConfig('payment/gerencianet_pix/chave_pix');
 	}
 
+	public function getPixExpiration()
+	{
+		return $this->getConfig('payment/gerencianet_pix/validade');
+	}
+
 	public function getStoreName()
 	{
 		return $this->getConfig('general/store_information/name');

--- a/Model/Payment/Pix.php
+++ b/Model/Payment/Pix.php
@@ -93,7 +93,7 @@ class Pix extends AbstractMethod
 			$options['pix_cert'] = $certificadoPix;
 
 			$data = [];
-			$data['calendario']['expiracao'] = 3600;
+			$data['calendario']['expiracao'] = $this->_helperData->getPixExpiration() ?? '3600';
 			if ($paymentInfo['documentType'] == "CPF") {
 				$data['devedor']['cpf'] = $paymentInfo['cpfCustomer'];
 			} else if ($paymentInfo['documentType'] == "CNPJ") {

--- a/Model/Payment/Pix.php
+++ b/Model/Payment/Pix.php
@@ -93,7 +93,7 @@ class Pix extends AbstractMethod
 			$options['pix_cert'] = $certificadoPix;
 
 			$data = [];
-			$data['calendario']['expiracao'] = $this->_helperData->getPixExpiration() ?? '3600';
+			$data['calendario']['expiracao'] = $this->_helperData->getPixExpiration() ?? 3600;
 			if ($paymentInfo['documentType'] == "CPF") {
 				$data['devedor']['cpf'] = $paymentInfo['cpfCustomer'];
 			} else if ($paymentInfo['documentType'] == "CNPJ") {


### PR DESCRIPTION
### Problema: 
Pix sempre com validade de 3600 (1h).

### Solução aplicada:
Atualmente o tempo de validade do PIX esta fixo para 3600, mesmo que seja alterada nas configurações do modulo no painel admin do Magento, esse PR resolve esta questão pegando o valor que foi informado no painel e usando ele na criação da cobrança.